### PR TITLE
fix: wrong offset in ondrag for dropPosition calculation

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -219,6 +219,16 @@ export function getNodeFromPath<T>(rootData: TreeData<T>[], path: number[]) {
   return node
 }
 
+function getGlobalOffset(dropTarget: HTMLElement) {
+  let offset = 0
+  let currentElem = dropTarget
+  while (currentElem) {
+    offset += currentElem.offsetTop
+    currentElem = currentElem.offsetParent
+  }
+  return offset
+}
+
 function getDropPosition(pageY: number, offsetTop: number, offsetHeight: number) {
   const top = pageY - offsetTop
   if (top < offsetHeight / 3) {
@@ -252,7 +262,8 @@ export function ondrag<T>(pageY: number, dragTarget: HTMLElement | null, dropTar
       const targetPath = dropTargetPathString.split(',').map(s => +s)
       const targetData = getNodeFromPath(data, targetPath)!
       const sourceData = getNodeFromPath(data, sourcePath)!
-      const position = getDropPosition(pageY, dropTarget.offsetTop, dropTarget.offsetHeight)
+      const offsetTop = getGlobalOffset(dropTarget)
+      const position = getDropPosition(pageY, offsetTop, dropTarget.offsetHeight)
       if (targetData.state.dropPosition !== position) {
         targetData.state.dropPosition = position
         const dropData: DropData<T> = {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -224,7 +224,7 @@ function getGlobalOffset(dropTarget: HTMLElement) {
   let currentElem = dropTarget
   while (currentElem) {
     offset += currentElem.offsetTop
-    currentElem = currentElem.offsetParent
+    currentElem = currentElem.offsetParent as HTMLElement
   }
   return offset
 }


### PR DESCRIPTION
#### Fixes(if relevant): 
Fixes wrong offset calculation, if tree is nested in another element. Fixed by getting offset and parents offsets (possible partial fix for #7)
#### Checks

+ [X] Contains Only One Commit(`git reset` then `git commit`)
+ [X] Build Success(`npm run build`)
+ [X] Lint Success(`npm run lint` to check, `npm run fix` to fix)
+ [ ] Add Test(if relevant, `npm run test` to check)
+ [ ] Add Demo(if relevant)
