### PR TITLE
fix: drag behaviour for custom vue component

### DIFF
--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -213,7 +213,7 @@ export class Tree<T> extends Vue {
     }
     return hasPath
   }
-  private containsNode(parentNode: HTMLElement, node: HTMLElement) {
+  private containsNode(parentNode: HTMLElement, node: HTMLElement): boolean {
     for (let i = 0; i < parentNode.children.length; i++) {
       const child = parentNode.children[i] as HTMLElement
       if (child === node) {
@@ -226,7 +226,7 @@ export class Tree<T> extends Vue {
     return false
   }
   private getAnchor(target: HTMLElement) {
-    let anchor = target as HTMLElement
+    let anchor = target
     while (anchor && anchor.classList && !anchor.classList.contains('tree-anchor')) {
       anchor = anchor.parentElement as HTMLElement
     }


### PR DESCRIPTION
#### Fixes(if relevant): 
The drag events don't work with custom vue components in the current version (5.3.2), because `event.target` is no longer the `<a>`, but an element inside the custom component. To fix this, I added a function to get the anchor element by going up one level in the DOM until the anchor (class `tree-anchor`) is found.
I also had to add a check to `ondragleave`, because the drag event is still fired on the `event.target`, but `this.dropTarget` is the anchor (returned by my other function). The function checks if `event.target` is a child element of `this.dropTarget`.
There is one lint error left, but I don't know how to fix it. If you could help me again with that, that would be great :)
This patch should fix #7 

#### Checks

+ [X] Contains Only One Commit(`git reset` then `git commit`)
+ [ ] Build Success(`npm run build`)
+ [ ] Lint Success(`npm run lint` to check, `npm run fix` to fix)
+ [ ] Add Test(if relevant, `npm run test` to check)
+ [ ] Add Demo(if relevant)
