### PR TITLE
fix droptarget page offset calculation

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -235,7 +235,7 @@ function getGlobalOffset(dropTarget: HTMLElement) {
   let offset = 0
   let currentElem = dropTarget
   while (currentElem) {
-    offset += currentElem.offsetTop
+    offset += (currentElem.offsetTop - currentElem.scrollTop)
     currentElem = currentElem.offsetParent as HTMLElement
   }
   return offset


### PR DESCRIPTION
#### Fixes(if relevant): 

#7 again...

#### Checks

+ [x] Contains Only One Commit(`git reset` then `git commit`)
+ [x] Build Success(`npm run build`)
+ [x] Lint Success(`npm run lint` to check, `npm run fix` to fix)
+ [ ] Add Test(if relevant, `npm run test` to check)
+ [ ] Add Demo(if relevant)

While working on fixing my issues (#23 #24) I came across a weird behavior. I couldn't drop elements on other elements. Only above. After some digging I found the problem. It was the fix I introduced in #17 
I think I have revamped my own tree layout since then and the (introduced by #17) `getGlobalOffset()` calculates a wrong value as it calculates the offset including scrolled containers, which may result in a very high offset. I fixed it (for me) by replacing the code of `getGlobalOffset()` with 
```javascript
function getGlobalOffset(dropTarget) {
    return dropTarget ? dropTarget.getBoundingClientRect().y : 0;
}
```

This should return the y value in px of the drop target element on the screen. And this should be comparable to the y value of pageY. If I'm correct, this should be the final solution :sweat_smile: What do you think? Feel free to edit, ...